### PR TITLE
Use make -j2 for compiling

### DIFF
--- a/src/build/compile.sh
+++ b/src/build/compile.sh
@@ -63,7 +63,7 @@ echo -n " checking..."
 cd libedit
 ./configure --prefix="$DIR/install_data/php/ext/libedit" --enable-static >> "$DIR/install.log" 2>&1
 echo -n " compiling..."
-if make >> "$DIR/install.log" 2>&1; then
+if make -j2 >> "$DIR/install.log" 2>&1; then
 	echo -n " installing..."
 	make install >> "$DIR/install.log" 2>&1
 	HAVE_LIBEDIT="--with-libedit=$DIR/install_data/php/ext/libedit"
@@ -85,7 +85,7 @@ cd zlib
 ./configure --prefix="$DIR/install_data/php/ext/zlib" \
 --static >> "$DIR/install.log" 2>&1
 echo -n " compiling..."
-make >> "$DIR/install.log" 2>&1
+make -j2 >> "$DIR/install.log" 2>&1
 echo -n " installing..."
 make install >> "$DIR/install.log" 2>&1
 echo -n " cleaning..."
@@ -113,7 +113,7 @@ cd curl
 --prefix="$DIR/install_data/php/ext/curl" \
 --disable-shared >> "$DIR/install.log" 2>&1
 echo -n " compiling..."
-make >> "$DIR/install.log" 2>&1
+make -j2 >> "$DIR/install.log" 2>&1
 echo -n " installing..."
 make install >> "$DIR/install.log" 2>&1
 echo -n " cleaning..."
@@ -183,7 +183,7 @@ rm -f ./configure >> "$DIR/install.log" 2>&1
 --without-pdo-sqlite \
 --with-zend-vm=$ZEND_VM >> "$DIR/install.log" 2>&1
 echo -n " compiling..."
-make >> "$DIR/install.log" 2>&1
+make -j2 >> "$DIR/install.log" 2>&1
 echo -n " installing..."
 make install >> "$DIR/install.log" 2>&1
 echo " done!"


### PR DESCRIPTION
Nowadays processors generally have 2 threads or more available, whether that is a single core CPU with 2 threads, or a dual core computer with 1 thread each. Make on 1 thread is very unbearably slow, especially when on an 8 core computer.
So I propose that this gets changed to make -j2 so it is faster on computers with the extra threads, and doesn't have much of an effect on those who do not have more than 1 thread.
