### PR TITLE
Fix: High CPU load (on idle)

### DIFF
--- a/src/PocketMinecraftServer.php
+++ b/src/PocketMinecraftServer.php
@@ -549,7 +549,7 @@ class PocketMinecraftServer{
 	}
 
 	public function process(){
-		$delay = 1
+		$delay = 1;
 		while($this->stop === false){
 			$packet = $this->interface->readPacket();
 			if($packet !== false){


### PR DESCRIPTION
When the server is idle the server keeps looping, consuming many
unneeded CPU-resources. If there was nothing to do the last cycle(s),
you can assume the next cycle will be idle as well. So I added an
incremental delay topping on 25msec (=40 TPS).

As soon as there is something to do, reset the delay...
