### PR TITLE
Fix leaves not dropping as blocks when broken using shears

### DIFF
--- a/src/material/block/solid/Leaves.php
+++ b/src/material/block/solid/Leaves.php
@@ -148,5 +148,9 @@ class LeavesBlock extends TransparentBlock{
 			$drops[] = array(APPLE, 0, 1);
 		}
 		return $drops;
+		if($item->isShears())
+                        $drops[] = array(LEAVES, $this-> meta & 0x03, 1);
+                return $drops;
+
 	}
 }


### PR DESCRIPTION
Added condition to drop leaves as blocks when the item in hand is shears
