### PR TITLE
Support other local date format for timezone detection to avoid startup errors

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -28,7 +28,7 @@ if(strpos(" ".strtoupper(php_uname("s")), " WIN") !== false){
 	exec("time.exe /T", $hour);
 	$i = array_map("intval", explode(":", trim($hour[0])));
 	exec("date.exe /T", $date);
-	$j = array_map("intval", explode("/", trim($date[0])));
+	$j = array_map("intval", explode(substr($date[0], 2, 1), trim($date[0])));
 	$offset = round((mktime($i[0], $i[1], 0, $j[1], $j[0], $j[2]) - $time) / 60) * 60;
 }else{
 	exec("date +%s", $t);


### PR DESCRIPTION
To delimit the year, month and day date.exe uses either /, - or . which depends on the system locale.

This hotfix reads the third character of the date.exe output, which should be an occurence of the delimiter and uses it instead of the previously hard-coded '/' delimiter.

fixes PocketMine/PocketMine-MP#718
