### PR TITLE
Fix argument parsing

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -142,7 +142,7 @@ function arguments ( $args ){
     array_shift( $args );
     $args = join( $args, ' ' );
 
-    preg_match_all('/ (--[\w\-]+ (?:[= ] [^-]+ [^\s-] )? ) | (-\w+) | (\w+) /x', $args, $match );
+    preg_match_all('/ (--[\w\-]+ (?:[= ] [^-\s]+ )? ) | (-\w+) | (\w+) /x', $args, $match );
     $args = array_shift( $match );
 
     $ret = array(


### PR DESCRIPTION
This fixes a bug with parsing arguments with only 1 character:

Test code:
$args = '--data-path /home/pocketserver/worlds/sphaxzmcpeserver --server-port 43722 --max-players 8 --enable-ansi false --memory-limit 128M';
preg_match_all('/ (--[\w-]+ (?:[= ] [^-\s]+ )? ) | (-\w+) | (\w+) /x', $args, $match );
$args = array_shift( $match );
print_r($args);

Old code:
Array
(
    [0] => --data-path /home/pocketserver/worlds/sphaxzmcpeserver
    [1] => --server-port 43722
    [2] => --max-players
    [3] => 8
    [4] => --enable-ansi false
    [5] => --memory-limit 128M
)

New Code:
Array
(
    [0] => --data-path /home/pocketserver/worlds/sphaxzmcpeserver
    [1] => --server-port 43722
    [2] => --max-players 8
    [3] => --enable-ansi false
    [4] => --memory-limit 128M
)
