### PR TITLE
AchievmentAPI logic change

### DIFF
--- a/src/API/AchievementAPI.php
+++ b/src/API/AchievementAPI.php
@@ -76,7 +76,7 @@ class AchievementAPI{
 		"buildBetterPickaxe" => array(
 			"name" => "Getting an Upgrade",
 			"requires" => array(
-				"buildWorkBench",
+				"buildPickaxe",
 			),
 		),
 		"buildSword" => array(


### PR DESCRIPTION
Tiny logic change to buildBetterPickaxe.
Instead of requiring buildWorkBench, it requires buildPickaxe, which in turn requires buildWorkBench
