### PR TITLE
default arguments missing

### DIFF
--- a/src/API/ServerAPI.php
+++ b/src/API/ServerAPI.php
@@ -380,7 +380,7 @@ class ServerAPI{
 		return $this->server->handle($e, $d);
 	}
 
-	public function schedule($t, $c, $d, $r = false, $e = "server.schedule"){
+	public function schedule($t, $c, $d=array(), $r = false, $e = "server.schedule"){
 		return $this->server->schedule($t, $c, $d, $r, $e);
 	}
 
@@ -388,7 +388,7 @@ class ServerAPI{
 		return $this->server->event($e, $d);
 	}
 
-	public function trigger($e, $d){
+	public function trigger($e, $d=""){
 		return $this->server->trigger($e, $d);
 	}
 


### PR DESCRIPTION
default argument 3 for ServerAPI::schedule() and argument 2 for ServerAPI::trigger() missing

with reference from PocketMinecraftServer.php
