### PR TITLE
Ignore Eclipse files and server folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,21 @@
-players/*
-worlds/*
-plugins/*
-logs/*
-bin/*
-.idea/*
+############
+## Server
+############
+logs/
+players/
+plugins/
+worlds/
 *.log
 *.pmf
 *.txt
 server.properties
+
+############
+## IDE
+############
+.idea/
+.project
+.buildpath
 
 
 ############


### PR DESCRIPTION
Note: patters such as

```
-players/*
-worlds/*
```

will exclude the contents of those folders from the repository, but not the folders actually.
