### PR TITLE
BOOK ID missing?

### DIFF
--- a/src/constants/ItemIDs.php
+++ b/src/constants/ItemIDs.php
@@ -113,6 +113,7 @@ define("SUGARCANE", 338);
 define("SUGAR_CANE", 338);
 define("SUGAR_CANES", 338);
 define("PAPER", 339);
+define("BOOK", 340);
 define("SLIMEBALL", 341);
 
 define("EGG", 344);


### PR DESCRIPTION
Maybe it is my error... but by searching on GitHub the only occurrences of "BOOK" are README.md and CraftingRecipes.php
