### PR TITLE
Certain usernames are very dangerous to plugins and robots and other types of code

### DIFF
--- a/src/Player.php
+++ b/src/Player.php
@@ -1311,7 +1311,7 @@ class Player{
 					$this->close("Incorrect protocol #".$packet->protocol1, false);
 					return;
 				}
-				if(preg_match('#[^a-zA-Z0-9_]#', $packet->username) > 0 or $packet->username === ""){
+				if(preg_match('#[^a-zA-Z0-9_]#', $packet->username) > 0 or $packet->username === "" or $packet->username === "console" or $packet->username === "rcon"){
 					$this->close("Bad username", false);
 					return;
 				}


### PR DESCRIPTION
Disallow players to log in with misleading (to robots) usernames.

Example of misleading (to robots):

``` php
public function eventHandler($data, $evt){
  if($evt == "console.command"){
    $cmd=$data["cmd"];
    $args=$data["parameters"];
    $issuer="{$data["issuer"]}";
    if(in_array("$issuer", array("rcon", "console"))
      $hasPower = true;
  }
}
```
