### PR TITLE
Space between plugin prefix/name and message for PluginLogger::log() added.

### DIFF
--- a/src/pocketmine/plugin/PluginLogger.php
+++ b/src/pocketmine/plugin/PluginLogger.php
@@ -39,6 +39,6 @@ class PluginLogger{
 	 * @param string $message
 	 */
 	public function log($message){
-		console($this->pluginName . $message);
+		console($this->pluginName . " " . $message);
 	}
 }


### PR DESCRIPTION
Just a visual effect.
