### PR TITLE
Multiple permissions checked in Server::broadcast()

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1476,21 +1476,24 @@ class Server{
 
 	/**
 	 * @param string $message
-	 * @param string $permission
+	 * @param string $permissions
 	 *
 	 * @return int
 	 */
-	public function broadcast($message, $permission){
-		$count = 0;
-		foreach($this->pluginManager->getPermissionSubscriptions($permission) as $permissible){
-			if($permissible instanceof CommandSender and $permissible->hasPermission($permission)){
-				$permissible->sendMessage($message);
-				++$count;
+	public function broadcast($message, $permissions){
+		$recipients = [];
+		foreach(explode(";", $permissions) as $permission){
+			foreach($this->pluginManager->getPermissionSubscriptions($permission) as $permissible){
+				if($permissible instanceof CommandSender and $permissible->hasPermission($permission)){
+					$recipients[spl_object_hash($permissible)] = $permissible; // do not send messages directly, or some might be repeated
+				}
 			}
 		}
-
-		return $count;
-	}
+		foreach($recipients as $recipient){
+			$recipient->sendMessage($message);
+		}
+		return count($recipients);
+  	}
 
 	/**
 	 * Broadcasts a Minecraft packet to a list of players


### PR DESCRIPTION
Sorry for double commit.
This is done like the one in `Command::testPermissionSilent()`, where permissions are connected via semicolons (`;`) and they are checked with `OR`, where the player must have at least one permission to read.
