### PR TITLE
Fixed PlayerMetadataStore

### DIFF
--- a/src/pocketmine/metadata/PlayerMetadataStore.php
+++ b/src/pocketmine/metadata/PlayerMetadataStore.php
@@ -21,13 +21,13 @@
 
 namespace pocketmine\metadata;
 
-use pocketmine\OfflinePlayer;
+use pocketmine\IPlayer;
 
 class PlayerMetadataStore extends MetadataStore{
 
 	public function disambiguate(Metadatable $player, $metadataKey){
-		if(!($player instanceof OfflinePlayer)){
-			throw new \InvalidArgumentException("Argument must be an OfflinePlayer instance");
+		if(!($player instanceof IPlayer)){
+			throw new \InvalidArgumentException("Argument must be an IPlayer instance");
 		}
 
 		return strtolower($player->getName()) . ":" . $metadataKey;


### PR DESCRIPTION
Player doesn't extend OfflinePlayer, so it wasn't possible to use metadata with Player.
