### PR TITLE
Update cause of lava and fire damage

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -436,7 +436,7 @@ abstract class Entity extends Position implements Metadatable{
 				}
 			}else{
 				if(($this->fireTicks % 20) === 0){
-					$this->attack(1, "onFire");
+					$this->attack(1, EntityDamageEvent::CAUSE_FIRE_TICK);
 				}
 				--$this->fireTicks;
 			}
@@ -444,7 +444,7 @@ abstract class Entity extends Position implements Metadatable{
 		}
 
 		if($this->handleLavaMovement()){
-			$this->attack(4, "lava");
+			$this->attack(4, EntityDamageEvent::CAUSE_LAVA);
 			$this->setOnFire(15);
 			$hasUpdate = true;
 			$this->fallDistance *= 0.5;


### PR DESCRIPTION
The causes, as seen in the PHPDoc comment for `Entity::attack()`, should be either an `EntityDamageEvent` instance or an integer constant at `EntityDamageEvent` class. I believe that it is intended to use constants instead of strings.
