### PR TITLE
Add support for generating terrain in a separate process

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -41,6 +41,7 @@ use pocketmine\inventory\InventoryType;
 use pocketmine\inventory\Recipe;
 use pocketmine\item\Item;
 use pocketmine\level\format\LevelProviderManager;
+use pocketmine\level\generator\ExternalGenerationRequestManager;
 use pocketmine\level\generator\GenerationRequestManager;
 use pocketmine\level\generator\Generator;
 use pocketmine\level\Level;
@@ -1483,7 +1484,11 @@ class Server{
 
 		$this->enablePlugins(PluginLoadOrder::STARTUP);
 
-		$this->generationManager = new GenerationRequestManager($this);
+		if ($this->getConfigBoolean("external-generation", false)) {
+			$this->generationManager = new ExternalGenerationRequestManager($this);
+		} else {
+			$this->generationManager = new GenerationRequestManager($this);
+		}
 
 		LevelProviderManager::addProvider($this, "pocketmine\\level\\format\\anvil\\Anvil");
 

--- a/src/pocketmine/level/generator/ExternalGenerationRequestManager.php
+++ b/src/pocketmine/level/generator/ExternalGenerationRequestManager.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\level\generator;
+
+use pocketmine\level\format\SimpleChunk;
+use pocketmine\level\Level;
+use pocketmine\Server;
+use pocketmine\utils\Binary;
+
+class ExternalGenerationRequestManager extends GenerationRequestManager {
+
+	protected $socket;
+	/** @var Server */
+	protected $server;
+	/** @var GenerationThread */
+	protected $generationThread;
+
+	/**
+	 * @param Server $server
+	 */
+	public function __construct(Server $server){
+		$this->server = $server;
+		$this->socket = $this->makeExternalClient();
+	}
+
+	private function makeExternalClient() {
+		if (($sock = socket_create(AF_UNIX, SOCK_STREAM, 0)) === false) {
+		    echo "socket_create() failed: reason: " . socket_strerror(socket_last_error()) . "\n";
+		}
+		$addr = "/tmp/pocketmine_external_generator_" . getmypid();
+		socket_bind($sock, $addr);
+		socket_listen($sock);
+		// start the external server
+		$cmdline = $this->server->getConfigString("external-generation-cmd", "hhvm -v Eval.Jit=true");
+		exec($cmdline . " " . \pocketmine\PATH . "src/pocketmine/level/generator/ExternalGeneratorEntryPoint.php " . $addr .
+			" > /tmp/pmexternal 2>&1 &");
+		// wait for a connection
+
+		$clientSock = socket_accept($sock);
+		socket_set_nonblock($clientSock);
+		@socket_set_option($clientSock, SOL_SOCKET, SO_SNDBUF, 1024 * 1024 * 2);
+		@socket_set_option($clientSock, SOL_SOCKET, SO_RCVBUF, 1024 * 1024 * 2);
+
+		socket_close($sock);
+		return $clientSock;
+	}
+
+	public function shutdown(){
+		$buffer = chr(GenerationManager::PACKET_SHUTDOWN);
+		@socket_write($this->socket, Binary::writeInt(strlen($buffer)) . $buffer);
+	}
+
+
+}

--- a/src/pocketmine/level/generator/ExternalGeneratorEntryPoint.php
+++ b/src/pocketmine/level/generator/ExternalGeneratorEntryPoint.php
@@ -1,0 +1,36 @@
+<?php
+namespace pocketmine\level\generator {
+
+	const VERSION = "Alpha_1.4dev";
+	const API_VERSION = "1.0.0";
+	const CODENAME = "絶好(Zekkou)ケーキ(Cake)";
+	const MINECRAFT_VERSION = "v0.9.0 alpha";
+	const PHP_VERSION = "5.5";
+	@define("pocketmine\\PATH", \getcwd() . DIRECTORY_SEPARATOR);
+
+	if(!class_exists("SplClassLoader", false)){
+		require_once(\pocketmine\PATH . "src/spl/SplClassLoader.php");
+	}
+
+	$autoloader = new \SplClassLoader();
+	$autoloader->setMode(\SplAutoloader::MODE_DEBUG);
+	$autoloader->add("pocketmine", [
+		\pocketmine\PATH . "src"
+	]);
+
+	$autoloader->register(true);
+
+	$opts = getopt("", array("enable-ansi", "disable-ansi", "data:", "plugins:", "no-wizard"));
+
+	define("pocketmine\\DATA", isset($opts["data"]) ? realpath($opts["data"]) . DIRECTORY_SEPARATOR : \getcwd() . DIRECTORY_SEPARATOR);
+
+	$logger = new \DumbLogger();
+
+	$sock = socket_create(AF_UNIX, SOCK_STREAM, 0);
+	socket_connect($sock, $argv[1]);
+	socket_set_block($sock); //IMPORTANT!
+	@socket_set_option($sock, SOL_SOCKET, SO_SNDBUF, 1024 * 1024 * 2);
+	@socket_set_option($sock, SOL_SOCKET, SO_RCVBUF, 1024 * 1024 * 2);
+
+	$generationManager = new GenerationManager($sock, $logger, $autoloader);
+}

--- a/src/spl/DumbLogger.php
+++ b/src/spl/DumbLogger.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+class DumbLogger implements Logger{
+
+	/**
+	 * System is unusable
+	 *
+	 * @param string $message
+	 */
+	public function emergency($message) {
+		log("Emergency", $message);
+	}
+
+	/**
+	 * Action must me taken immediately
+	 *
+	 * @param string $message
+	 */
+	public function alert($message) {
+		log("Alert", $message);
+	}
+	/**
+	 * Critical conditions
+	 *
+	 * @param string $message
+	 */
+	public function critical($message) {
+		log("Critical", $message);
+	}
+
+	/**
+	 * Runtime errors that do not require immediate action but should typically
+	 * be logged and monitored.
+	 *
+	 * @param string $message
+	 */
+	public function error($message) {
+		log("Error", $message);
+	}
+
+	/**
+	 * Exceptional occurrences that are not errors.
+	 *
+	 * Example: Use of deprecated APIs, poor use of an API, undesirable things
+	 * that are not necessarily wrong.
+	 *
+	 * @param string $message
+	 */
+	public function warning($message) {
+		log("Warning", $message);
+	}
+
+	/**
+	 * Normal but significant events.
+	 *
+	 * @param string $message
+	 */
+	public function notice($message) {
+		log("Notice", $message);
+	}
+
+	/**
+	 * Inersting events.
+	 *
+	 * @param string $message
+	 */
+	public function info($message) {
+		log("Info", $message);
+	}
+
+	/**
+	 * Detailed debug information.
+	 *
+	 * @param string $message
+	 */
+	public function debug($message) {
+		log("Debug", $message);
+	}
+
+	/**
+	 * Logs with an arbitrary level.
+	 *
+	 * @param mixed  $level
+	 * @param string $message
+	}
+	 */
+	public function log($level, $message) {
+		echo($level . ": " . $message . "\n");
+	}
+}


### PR DESCRIPTION
For measuring CPU usage of the terrain gen separately from the main server.

The config option in server.properties is external-generation. To override the executable used to launch the external generator (the default is HHVM), use the option external-generation-cmd

The transport used is Unix sockets, like stock threaded generation. External generator logs are printed to /tmp/pmexternal

Caveats:
- Phar archived PocketMine distributions are not supported
- Doesn't run on Windows because of the usage of Unix sockets

Since this is meant as a debug option, I don't think those defects are important.
