### PR TITLE
Add getter for console command sender

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -512,6 +512,13 @@ class Server{
 	}
 
 	/**
+	 * @return ConsoleComamndSender
+	 */
+	public function getConsoleSender(){
+		return $this->consoleSender;
+	}
+
+	/**
 	 * @return ServerScheduler
 	 */
 	public function getScheduler(){


### PR DESCRIPTION
so that plugins don't have to instantiate it when console command sender is required.
