### PR TITLE
fix #1707

### DIFF
--- a/src/pocketmine/block/Stone.php
+++ b/src/pocketmine/block/Stone.php
@@ -33,7 +33,7 @@ class Stone extends Solid{
 	const POLISHED_ANDESITE = 6;
 
 	public function __construct($meta = 0){
-		parent::__construct(self::STONE, $meta, "Stone");
+		parent::__construct(parent::STONE, $meta, "Stone");
 		$names = [
 			self::STONE => "Stone",
 			self::GRANITE => "Granite",


### PR DESCRIPTION
there should be the ID of Stone(=1) but self::STONE means stone::STONE(=0,the damage of Stone).
To use block::STONE(=1,the ID of Stone),we should write "parent::STONE".
