### PR TITLE
Member access of PluginEvent changed to protected

### DIFF
--- a/src/pocketmine/event/plugin/PluginEvent.php
+++ b/src/pocketmine/event/plugin/PluginEvent.php
@@ -31,7 +31,7 @@ use pocketmine\plugin\Plugin;
 abstract class PluginEvent extends Event{
 
 	/** @var Plugin */
-	private $plugin;
+	protected $plugin;
 
 	public function __construct(Plugin $plugin){
 		$this->plugin = $plugin;


### PR DESCRIPTION
PluginDisableEvent and PluginEnableEvent edit this directly. Looks like better use the method in other abstract event classes (protected)
