### PR TITLE
Save the levels when server forced to shutdown

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1707,6 +1707,7 @@ class Server{
 		}
 
 		foreach($this->getLevels() as $level){
+			$level->save(true);
 			$this->unloadLevel($level, true);
 		}
 		$this->generationManager->shutdown();


### PR DESCRIPTION
You will no longer lost your worlds changes when your server forced to shutdown
