### PR TITLE
Remove similar player name check from the beginning limit

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -748,7 +748,7 @@ class Server{
 		$name = strtolower($name);
 		$delta = PHP_INT_MAX;
 		foreach($this->getOnlinePlayers() as $player){
-			if(stripos($player->getName(), $name) === 0){
+			if(stripos($player->getName(), $name) !== false){
 				$curDelta = strlen($player->getName()) - strlen($name);
 				if($curDelta < $delta){
 					$found = $player;


### PR DESCRIPTION
For example, some would like to write `map` for `pemapmodder`, and this is what existed in amai beetroot when we used `SQLite3::query("SELECT ... ALIKE")`. This feature should be allowed.
