### PR TITLE
Fixed error with useBreakOn parameters

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -775,7 +775,11 @@ class Level implements ChunkManager, Metadatable{
 	public function useBreakOn(Vector3 $vector, Item &$item = null, Player $player = null){
 		$target = $this->getBlock($vector);
 		//TODO: Adventure mode checks
-
+		
+		if($item == null){
+			$item = new Item(AIR);
+		}
+		
 		if($player instanceof Player){
 			$ev = new BlockBreakEvent($player, $target, $item, ($player->getGamemode() & 0x01) === 1 ? true : false);
 


### PR DESCRIPTION
A E_RECOVERABLE_ERROR error happened: "Argument 1 passed to pocketmine\block\Block::getDrops() must be an instance of pocketmine\item\Item, null given

AND

A E_RECOVERABLE_ERROR error happened: "Argument 1 passed to pocketmine\block\Generic::onBreak() must be an instance of pocketmine\item\Item, null given

are fixed
