### PR TITLE
new Item(Item::AIR) instead of new Air() which cause errors

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -776,7 +776,7 @@ class Level implements ChunkManager, Metadatable{
 		$target = $this->getBlock($vector);
 		//TODO: Adventure mode checks
 		
-		if($item === null) $item = new Air();
+		if($item === null) $item = new Item(Item::AIR);
 		
 		if($player instanceof Player){
 			$ev = new BlockBreakEvent($player, $target, $item, ($player->getGamemode() & 0x01) === 1 ? true : false);


### PR DESCRIPTION
A E_RECOVERABLE_ERROR error happened: "Argument 1 passed to pocketmine\block\Generic::onBreak() must be an instance of pocketmine\item\Item, instance of pocketmine\block\Air given

AND

A E_RECOVERABLE_ERROR error happened: "Argument 1 passed to pocketmine\block\Block::getDrops() must be an instance of pocketmine\item\Item, instance of pocketmine\block\Air given

Fixed
