### PR TITLE
Fixed an error related to AIR constant

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -776,7 +776,7 @@ class Level implements ChunkManager, Metadatable{
 		$target = $this->getBlock($vector);
 		//TODO: Adventure mode checks
 		
-		if($item === null) $item = new Air();
+		if($item === null) $item = Item::get(Item::AIR, 0, 0);
 		
 		if($player instanceof Player){
 			$ev = new BlockBreakEvent($player, $target, $item, ($player->getGamemode() & 0x01) === 1 ? true : false);


### PR DESCRIPTION
A E_NOTICE error happened: "Use of undefined constant AIR - assumed 'AIR'"

should be fixed
