### PR TITLE
Spelling

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1814,7 +1814,7 @@ class Server{
 			if(($data = json_decode($reply)) !== false and isset($data->crashId)){
 				$reportId = $data->crashId;
 				$reportUrl = $data->crashUrl;
-				$this->logger->emergency("The crash dump has ben automatically submitted to the Crash Archive. You can view it on $reportUrl or use the ID #$reportId.");
+				$this->logger->emergency("The crash dump has been automatically submitted to the Crash Archive. You can view it on $reportUrl or use the ID #$reportId.");
 			}
 		}
 


### PR DESCRIPTION
Fixed spelling for crashDump() success message.
