### PR TITLE
Improve behaviour of showPlayer()

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -283,8 +283,8 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 		}
 		unset($this->hiddenPlayers[$player->getName()]);
 		if($player->isOnline()){
-            $player->spawnTo($this);
-        }
+            		$player->spawnTo($this);
+        	}
 	}
 
 	/**


### PR DESCRIPTION
If you try to show a player who is offline a player will be spawned to the client even though the player is no longer connected. This way you can show player inside a quit event.
