### PR TITLE
Enabled the ability to use proxies (such as the docker-proxy :))

### DIFF
--- a/src/pocketmine/network/RakLibInterface.php
+++ b/src/pocketmine/network/RakLibInterface.php
@@ -109,6 +109,7 @@ class RakLibInterface implements ServerInstance, SourceInterface{
 		$server = new RakLibServer($this->server->getLogger(), $this->server->getLoader(), $this->server->getPort(), $this->server->getIp() === "" ? "0.0.0.0" : $this->server->getIp());
 		$this->interface = new ServerHandler($server, $this);
 		$this->setName($this->server->getMotd());
+		$this->setPortCheck($this->server->getProperty("settings.session-port-checking", true));
 		$this->tickTask = $this->server->getScheduler()->scheduleRepeatingTask(new CallbackTask([$this, "doTick"]), 1);
 	}
 

--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -16,6 +16,7 @@ settings:
  send-usage: true
  #Number of AsyncTask workers
  async-workers: 4
+ session-port-checking: true
 
 debug:
  #If > 1, it will show debug messages in the console


### PR DESCRIPTION
Prior to this commit, a user was unable to use proxies that were on alternate ports. This commit allows a user to enable this functionality by adding a key to the pocketmine.yml file.
