### PR TITLE
Removed argument from kill function

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -169,15 +169,15 @@ namespace pocketmine {
 		}
 	}
 
-	function kill($pid){
+	function kill(){
 		switch(Utils::getOS()){
 			case "win":
-				exec("taskkill.exe /F /PID " . ((int) $pid) . " > NUL");
+				exec("taskkill.exe /F /PID " . ((int) getmypid()) . " > NUL");
 				break;
 			case "mac":
 			case "linux":
 			default:
-				exec("kill -9 " . ((int) $pid) . " > /dev/null 2>&1");
+				exec("kill -9 " . ((int) getmypid()) . " > /dev/null 2>&1");
 		}
 	}
 

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1584,7 +1584,7 @@ class Server{
 		//Temporal workaround, pthreads static property nullification test
 		if(PluginManager::$pluginParentTimer === null){
 			$this->getLogger()->emergency("You are using an invalid pthreads version. Please update your binaries.");
-			kill(getmypid());
+			kill();
 			return;
 		}
 

--- a/src/pocketmine/wizard/Installer.php
+++ b/src/pocketmine/wizard/Installer.php
@@ -57,7 +57,7 @@ class Installer{
 		echo "[*] " . $this->lang->language_has_been_selected . "\n";
 
 		if(!$this->showLicense()){
-			\pocketmine\kill(getmypid());
+			\pocketmine\kill();
 			exit(-1);
 		}
 


### PR DESCRIPTION
I've removed the `$pid` argument from the `kill()` function, because I think that PocketMine will only have to kill itself (the PHP process) if it ever has to, and I'm not comfortable with PocketMine being able to -9 kill any process on my system.
If any of you guys disagree with me, please let me know, and post your arguments, I'm open to discussions :smile: 
