### PR TITLE
Update Player.php, fix SimpleAuth doesn't crash

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -551,7 +551,17 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 			return $level->getSafeSpawn();
 		}
 	}
-
+	
+	
+	public function getInAirTicks(){
+		return $this->inAirTicks;
+	}
+	
+	public function setInAirTicks($ticks){
+		$this->inAirTicks = $ticks;
+	}
+	
+	
 	/**
 	 * @param int $identifier
 	 *


### PR DESCRIPTION
Added get & set $this->inAirTicks to fix a crash of SimpleAuth, that does not have access to this property
