### PR TITLE
Added internal use warning for TaskHandler::cancel()

### DIFF
--- a/src/pocketmine/scheduler/TaskHandler.php
+++ b/src/pocketmine/scheduler/TaskHandler.php
@@ -127,6 +127,10 @@ class TaskHandler{
 		return $this->period;
 	}
 
+	/**
+	 * WARNING: Do not use this, it's only for internal use.
+	 * Changes to this function won't be recorded on the version.
+	 */
 	public function cancel(){
 		if(!$this->isCancelled()){
 			$this->task->onCancel();


### PR DESCRIPTION
It is confusing for some developers to whether to use this function or `ServerScheduler::cancelTask($taskId)`. It is better to add warning in the documentation.
