### PR TITLE
Added Plugin::onError() to handle plugin exceptions

### DIFF
--- a/src/pocketmine/plugin/Plugin.php
+++ b/src/pocketmine/plugin/Plugin.php
@@ -26,7 +26,6 @@ namespace pocketmine\plugin;
 
 use pocketmine\command\CommandExecutor;
 
-
 /**
  * It is recommended to use PluginBase for the actual plugin
  *
@@ -52,6 +51,12 @@ interface Plugin extends CommandExecutor{
 	public function onDisable();
 
 	public function isDisabled();
+	/**
+	 * Called when the plugin throws/triggers an exception during execution of commands, events or scheduled tasks before the exception is logged.
+	 * @param PluginError $error
+	 * @return bool whether the exception is consumed. If the error is consumed (handled, like events cancelled), PocketMine will not log the exception.
+	 */
+	public function onError(PluginError $error);
 
 	/**
 	 * Gets the plugin's data folder to save files and configuration

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -97,6 +97,14 @@ abstract class PluginBase implements Plugin{
 		return $this->isEnabled === false;
 	}
 
+	/**
+	 * @param PluginError $error
+	 * @return bool
+	 */
+	public function onError(PluginError $error){
+		return false;
+	}
+
 	public final function getDataFolder(){
 		return $this->dataFolder;
 	}

--- a/src/pocketmine/plugin/PluginCommandError.php
+++ b/src/pocketmine/plugin/PluginCommandError.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\plugin;
+
+use pocketmine\command\CommandSender;
+use pocketmine\command\PluginIdentifiableCommand;
+
+class PluginCommandError implements PluginError{
+
+	/** @var \Exception */
+	private $exception;
+	/** @var CommandSender */
+	private $sender;
+	/** @var \pocketmine\command\Command|PluginIdentifiableCommand */
+	private $cmd;
+	/** @var string */
+	private $label;
+	/** @var string[] */
+	private $args;
+	/**
+	 * @param \Exception                $exception
+	 * @param CommandSender             $sender
+	 * @param PluginIdentifiableCommand $cmd
+	 * @param string                    $label
+	 * @param string[]                  $args
+	 */
+	public function __construct(\Exception $exception, CommandSender $sender, PluginIdentifiableCommand $cmd, $label, array $args){
+		$this->exception = $exception;
+		$this->sender = $sender;
+		$this->cmd = $cmd;
+		$this->label = $label;
+		$this->args = $args;
+	}
+
+	/**
+	 * @return \Exception
+	 */
+	public function getException(){
+		return $this->exception;
+	}
+	/**
+	 * @return CommandSender
+	 */
+	public function getCommandSender(){
+		return $this->sender;
+	}
+	/**
+	 * @return \pocketmine\command\Command|PluginIdentifiableCommand
+	 */
+	public function getCommand(){
+		return $this->cmd;
+	}
+	/**
+	 * @return string
+	 */
+	public function getLabel(){
+		return $this->label;
+	}
+	/**
+	 * @return string[]
+	 */
+	public function getArgs(){
+		return $this->args;
+	}
+
+}

--- a/src/pocketmine/plugin/PluginError.php
+++ b/src/pocketmine/plugin/PluginError.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\plugin;
+
+interface PluginError{
+
+	/**
+	 * @return \Exception
+	 */
+	public function getException();
+
+}

--- a/src/pocketmine/plugin/PluginEventError.php
+++ b/src/pocketmine/plugin/PluginEventError.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\plugin;
+
+use pocketmine\event\Event;
+
+class PluginEventError implements PluginError{
+
+	/** @var \Exception */
+	private $ex;
+	/** @var Event */
+	private $event;
+	/** @var RegisteredListener */
+	private $registration;
+	public function __construct(\Exception $ex, Event $event, RegisteredListener $listener){
+		$this->ex = $ex;
+		$this->event = $event;
+		$this->registration = $listener;
+	}
+
+	/**
+	 * @return \Exception
+	 */
+	public function getException(){
+		return $this->ex;
+	}
+	/**
+	 * @return Event
+	 */
+	public function getEvent(){
+		return $this->event;
+	}
+	/**
+	 * @return RegisteredListener
+	 */
+	public function getRegistration(){
+		return $this->registration;
+	}
+
+}

--- a/src/pocketmine/plugin/PluginScheduleError.php
+++ b/src/pocketmine/plugin/PluginScheduleError.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+
+ *
+ *
+*/
+
+namespace pocketmine\plugin;
+
+use pocketmine\scheduler\PluginTask;
+
+class PluginScheduleError implements PluginError{
+	private $ex;
+	private $task;
+	public function __construct(\Exception $ex, PluginTask $task){
+		$this->ex = $ex;
+		$this->task = $task;
+	}
+	public function getException(){
+		return $this->ex;
+	}
+	/**
+	 * @return PluginTask
+	 */
+	public function getTask(){
+		return $this->task;
+	}
+}


### PR DESCRIPTION
I called it Error instead of Exception because some class names might therefore end in "Exception" and lead to confusion that they are subclasses of \Exception.

This change calls the Plugin::onError() method when an exception is thrown from a plugin command execution, event execution or a plugin task execution. This enables plugins to have features like auto-reporting exceptions to their authors or create other custom handlers.