### PR TITLE
Fixed /timings off

### DIFF
--- a/src/pocketmine/command/defaults/TimingsCommand.php
+++ b/src/pocketmine/command/defaults/TimingsCommand.php
@@ -60,6 +60,7 @@ class TimingsCommand extends VanillaCommand{
 		}elseif($mode === "off"){
 			$sender->getServer()->getPluginManager()->setUseTimings(false);
 			$sender->sendMessage("Disabled Timings");
+			return true;
 		}
 
 		if(!$sender->getServer()->getPluginManager()->useTimings()){


### PR DESCRIPTION
When issuing `/timings off`, the message `Please enable timings by typing /timings on` is sent to the issuer. This commit fixes this issue.