### PR TITLE
Improve FallingSand behaviour

### DIFF
--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -23,6 +23,8 @@ namespace pocketmine\entity;
 
 
 use pocketmine\block\Block;
+use pocketmine\block\Flowable;
+use pocketmine\block\Liquid;
 use pocketmine\event\entity\EntityBlockChangeEvent;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\EntityRegainHealthEvent;
@@ -111,7 +113,7 @@ class FallingSand extends Entity{
 			if($this->onGround){
 				$this->kill();
 				$block = $this->level->getBlock($pos);
-				if($block->getId() > 0 and !$block->isSolid()){
+				if($block->getId() > 0 and !$block->isSolid() and !($block instanceof Liquid)){
 					$this->getLevel()->dropItem($this, ItemItem::get($this->getBlock(), $this->getDamage(), 1));
 				}else{
 					$this->server->getPluginManager()->callEvent($ev = new EntityBlockChangeEvent($this, $block, Block::get($this->getBlock(), $this->getDamage())));


### PR DESCRIPTION
FallingSand should only turn into an item when it comes into a non-solid which isn't a liquid. This replicates the behaviour of MCPE. 

This issue was mentioned in #2522