### PR TITLE
Update and rename Ozelot.php to Ocelot.php

### DIFF
--- a/src/pocketmine/entity/Ocelot.php
+++ b/src/pocketmine/entity/Ocelot.php
@@ -22,6 +22,6 @@
 namespace pocketmine\entity;
 
 
-class Ozelot extends Animal implements Tameable{
+class Ocelot extends Animal implements Tameable{
 
 }


### PR DESCRIPTION
Fixed spelling of Ocelot. Not sure if this screws up backwards compatibility because no plugins actually use this class.