### PR TITLE
Added function to align lines with MCPE font

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -488,12 +488,12 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 	public function getNameTag(){
 		return $this->nameTag;
 	}
-
 	/**
 	 * @param string $name
+	 * @param int    $align default TextWrapper::ALIGN_LEFT
 	 */
-	public function setNameTag($name){
-		$this->nameTag = $name;
+	public function setNameTag($name, $align = TextWrapper::ALIGN_LEFT){
+		$this->nameTag = (($align === TextWrapper::ALIGN_LEFT) ? $name : TextWrapper::align(explode("\n", $name), $align));
 		$this->despawnFromAll();
 		if($this->spawned === true){
 			$this->spawnToAll();

--- a/src/pocketmine/utils/TextWrapper.php
+++ b/src/pocketmine/utils/TextWrapper.php
@@ -22,6 +22,9 @@
 namespace pocketmine\utils;
 
 abstract class TextWrapper{
+	const ALIGN_LEFT = 0;
+	const ALIGN_CENTRE = 1;
+	const ALIGN_RIGHT = 2;
 
 	private static $characterWidths = [
 		4, 2, 5, 6, 6, 6, 6, 3, 5, 5, 5, 6, 2, 6, 2, 6,
@@ -78,5 +81,56 @@ abstract class TextWrapper{
 		}
 
 		return $result;
+	}
+
+	public static function align($lines, $mode){
+		switch($mode){
+			case self::ALIGN_LEFT:
+				return implode("\n", $lines);
+
+			case self::ALIGN_CENTRE:
+				$lengths = array_map(self::class . "::getLength", $lines);
+				$maxLength = max($lengths);
+				$output = "";
+				foreach($lines as $i => $line){
+					$padding = ($maxLength - $lengths[$i]) / 2;
+					$spaces = (int) ($padding / 4); // 4 is the length of a space
+					$output .= str_repeat(" ", $spaces);
+
+					$output .= $line;
+					$output .= "\n";
+				}
+				return substr($output, 0, -1);
+
+			case self::ALIGN_RIGHT:
+				$lengths = array_map(self::class . "::getLength", $lines);
+				$maxLength = max($lengths);
+				$output = "";
+				foreach($lines as $i => $line){
+					$padding = $maxLength - $lengths[$i];
+					$spaces = (int) ($padding / 4); // 4 is the length of a space
+					$output .= str_repeat(" ", $spaces);
+
+					$output .= $line;
+					$output .= "\n";
+				}
+				return substr($output, 0, -1);
+
+			default:
+				throw new \InvalidArgumentException("Unknown alignment mode $mode");
+		}
+	}
+
+	public static function getLength($line, $utfValue = 8){
+		$len = 0;
+		for($i = 0; $i < strlen($line); $i++){
+			if(isset(self::$allowedCharsArray[$char = $line{$i}])){
+				$len += self::$allowedCharsArray[$char];
+			}
+			else{
+				$len += $utfValue; // assumed value
+			}
+		}
+		return $len;
 	}
 }


### PR DESCRIPTION
A shorthand method for doing this in `Player::setNametag()` was added.

* Backwards-compatible
* Recommended tags: `PR: Contribution`

API Changes:
* Changed `public function pocketmine\Player::setNametag(string $name)` to `public function pocketmine\Player::setNametag(string $name, int $align = pocketmine\utils\TextWrapper::ALIGN_LEFT` (it will _not_ affect calls expecting older versions)
* Added `public static function pocketmine\utils\TextWrapper::align(string[] $lines, int $mode) throws InvalidArgumentException`
* Added `public static function pocketmine\utils\TextWrapper::getLength(string $line, int $utfValue = 8)`

Widths of characters not included in `pocketmine\utils\TextWrapper::$allowedChars` are assumed as 8.