### PR TITLE
Allow array's in Player::sendMessage()

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2381,6 +2381,9 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 	 * @param string $message
 	 */
 	public function sendMessage($message){
+		if(is_array($message)) {
+			$message = implode("\n",$message);
+		}
 		if($this->removeFormat !== false){
 			$message = TextWrapper::wrap(TextFormat::clean($message));
 		}


### PR DESCRIPTION
Means we can do Player::sendMessage(["Hi", "Hello Again!!", "You're Back!! Yay!"]);

Also reduces the need to have foreach($messages as $message) loops whenever sending multiple lines in one go.