### PR TITLE
If flying kick cancelled, fly movements doesn't prevent

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1278,8 +1278,7 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 						if($this->inAirTicks < 100){
 							$this->setMotion(new Vector3(0, $expectedVelocity, 0));
 						}else{
-							$this->kick("Flying is not enabled on this server");
-							return false;
+							if($this->kick("Flying is not enabled on this server")) return false;
 						}
 					}
 				}


### PR DESCRIPTION
like a trampolines, some plugins need
*'flying prevent' and an exception is required*
current code is, even fly kick canceled all movement is prevented