### PR TITLE
Added double chest fix

### DIFF
--- a/src/pocketmine/inventory/BaseInventory.php
+++ b/src/pocketmine/inventory/BaseInventory.php
@@ -109,13 +109,15 @@ abstract class BaseInventory implements Inventory{
 			$items = array_slice($items, 0, $this->size, true);
 		}
 
-		for($i = 0; $i < $this->size; ++$i){
+		for ($i = 0; $i < $this->size; ++$i){
 			if(!isset($items[$i])){
 				if(isset($this->slots[$i])){
 					$this->clear($i);
 				}
 			}else{
-				$this->setItem($i, $items[$i]);
+				if (!$this->setItem($i, $items[$i])){
+					$this->clear($i);
+				}
 			}
 		}
 	}

--- a/src/pocketmine/inventory/DoubleChestInventory.php
+++ b/src/pocketmine/inventory/DoubleChestInventory.php
@@ -37,7 +37,8 @@ class DoubleChestInventory extends ChestInventory implements InventoryHolder{
 	public function __construct(Chest $left, Chest $right){
 		$this->left = $left->getRealInventory();
 		$this->right = $right->getRealInventory();
-		BaseInventory::__construct($this, InventoryType::get(InventoryType::DOUBLE_CHEST));
+		$items = array_merge($this->left->getContents(), $this->right->getContents());
+		BaseInventory::__construct($this, InventoryType::get(InventoryType::DOUBLE_CHEST), $items);
 	}
 
 	public function getInventory(){
@@ -77,13 +78,26 @@ class DoubleChestInventory extends ChestInventory implements InventoryHolder{
 			$items = array_slice($items, 0, $this->size, true);
 		}
 
-		parent::setContents($items);
 
-		$leftItems = array_slice($items, 0, $this->left->getSize(), true);
-		$this->left->setContents($leftItems);
-		if(count($items) > $this->left->getSize()){
-			$rightItems = array_slice($items, $this->left->getSize() - 1, $this->right->getSize(), true);
-			$this->right->setContents($rightItems);
+		for ($i = 0; $i < $this->size; ++$i) {
+			if(!isset($items[$i])){
+				if ($i < $this->left->size)
+				{
+					if (isset($this->left->slots[$i])) {
+						$this->clear($i);
+					}
+				}
+				else 
+				{
+					if (isset($this->right->slots[$i - $this->left->size])) {
+						$this->clear($i);
+					}
+				}
+			}else{
+				if (!$this->setItem($i, $items[$i])){
+					$this->clear($i);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Added a fix for the double chest Issue #2493

The data wasn't always going into the doublechest, and didn't appear to be combining correctly upon logout/login of server.

##### Double Chest Changes:

The doublechest, now starts with the items created from left/right in it's constructor.

Then in it's setContent's function. It now doesn't call parent (as the slot[] check is invalid and won't check both chests) but now has a similar pattern using the slots[] of left and right.

##### Minor improvement to base inventory:

When you set contents to an inventory, I now clear if the 'SetItem' fails.