### PR TITLE
Fixed bug where non-default generators are ignored in pocketmine\Server.php

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1139,9 +1139,7 @@ class Server{
 
 		$seed = $seed === null ? Binary::readInt(@Utils::getRandomBytes(4, false)) : (int) $seed;
 
-		if($generator !== null and class_exists($generator) and is_subclass_of($generator, Generator::class)){
-			$generator = new $generator($options);
-		}else{
+		if($generator === null or !class_exists($generator) or !is_subclass_of($generator, Generator::class)){
 			$options["preset"] = $this->getConfigString("generator-settings", "");
 			$generator = Generator::getGenerator($this->getLevelType());
 		}


### PR DESCRIPTION
Setting *FLAT* on `server.properties` or `pocketmine.yml` does not work, i.e. it is ignored by `LevelProvider::generator`.

The issue is that Server.php will create a new $generator instance, while `LevelProvide::generate` expects a string with the class name and an options array.
