### PR TITLE
Fix some Chunk corruption due to Chunk overlap

### DIFF
--- a/src/pocketmine/level/format/mcregion/RegionLoader.php
+++ b/src/pocketmine/level/format/mcregion/RegionLoader.php
@@ -247,7 +247,8 @@ class RegionLoader{
 			$chunk = Binary::writeInt(strlen($chunk)) . $chunk;
 			$sectors = (int) ceil(strlen($chunk) / 4096);
 			if($sectors > $this->locationTable[$i][1]){
-				$this->locationTable[$i][0] = $this->lastSector += $sectors;
+				$this->locationTable[$i][0] = $this->lastSector + 1;
+				$this->lastSector += $sectors;
 			}
 			fseek($this->filePointer, $this->locationTable[$i][0] << 12);
 			fwrite($this->filePointer, str_pad($chunk, $sectors << 12, "\x00", STR_PAD_RIGHT));

--- a/src/pocketmine/level/format/mcregion/RegionLoader.php
+++ b/src/pocketmine/level/format/mcregion/RegionLoader.php
@@ -189,8 +189,8 @@ class RegionLoader{
 		$sectors = (int) ceil(($length + 4) / 4096);
 		$index = self::getChunkOffset($x, $z);
 		if($this->locationTable[$index][1] < $sectors){
+			$this->locationTable[$index][0] = $this->lastSector+1;
 			$this->lastSector += $sectors; //The GC will clean this shift "later"
-			$this->locationTable[$index][0] = $this->lastSector;
 		}
 		$this->locationTable[$index][1] = $sectors;
 		$this->locationTable[$index][2] = time();


### PR DESCRIPTION
When a chunks start going over 2 sectors, they begin to overlap which causes chunk corruption.

What happens is that `RegionLoader->lastSector` points to the last used sector.  When we try to save a Chunk that uses `2` sectors, the code afer line 191 gets executed.  The current behaviour is:

Extend lastSector by the number of sectors, then make the chunk index point to that lastSector.

This means that the chunk will start writing at the lastSector location but because it takes more than `1` sector of space, the next chunk that needs to allocate a sector will overwrite this chunk thus causing corruption.

This fix changes the code to:

Make chunk index point to lastSector+1, extent lastSector +  number of sectors needed.
