### PR TITLE
Clone initial chunk in Flat.php

### DIFF
--- a/src/pocketmine/level/generator/Flat.php
+++ b/src/pocketmine/level/generator/Flat.php
@@ -59,6 +59,7 @@ class Flat extends Generator{
 		$this->preset = "2;7,2x3,2;1;";
 		//$this->preset = "2;7,59x1,3x3,2;1;spawn(radius=10 block=89),decoration(treecount=80 grasscount=45)";
 		$this->options = $options;
+		$this->chunk = null;
 
 		if(isset($this->options["decoration"])){
 			$ores = new Ore();
@@ -80,7 +81,7 @@ class Flat extends Generator{
 		}*/
 	}
 
-	protected function parsePreset($preset){
+	protected function parsePreset($preset, $chunkX, $chunkZ){
 		$this->preset = $preset;
 		$preset = explode(";", $preset);
 		$version = (int) $preset[0];
@@ -106,7 +107,7 @@ class Flat extends Generator{
 		}
 
 
-		$this->chunk = clone $this->level->getChunk(0, 0);
+		$this->chunk = $this->level->getChunk($chunkX, $chunkZ);
 		$this->chunk->setGenerated();
 
 		for($Z = 0; $Z < 16; ++$Z){
@@ -139,15 +140,24 @@ class Flat extends Generator{
 		$this->level = $level;
 		$this->random = $random;
 
+		/*
+		  // Commented out : We want to delay this
 		if(isset($this->options["preset"]) and $this->options["preset"] != ""){
 			$this->parsePreset($this->options["preset"]);
 		}else{
 			$this->parsePreset($this->preset);
 		}
-
+		*/
 	}
 
 	public function generateChunk($chunkX, $chunkZ){
+		if($this->chunk === null) {
+			if(isset($this->options["preset"]) and $this->options["preset"] != ""){
+				$this->parsePreset($this->options["preset"], $chunkX, $chunkZ);
+			}else{
+				$this->parsePreset($this->preset, $chunkX, $chunkZ);
+			}
+		}
 		$chunk = clone $this->chunk;
 		$chunk->setX($chunkX);
 		$chunk->setZ($chunkZ);

--- a/src/pocketmine/level/generator/Flat.php
+++ b/src/pocketmine/level/generator/Flat.php
@@ -107,7 +107,7 @@ class Flat extends Generator{
 		}
 
 
-		$this->chunk = $this->level->getChunk($chunkX, $chunkZ);
+		$this->chunk = clone $this->level->getChunk($chunkX, $chunkZ);
 		$this->chunk->setGenerated();
 
 		for($Z = 0; $Z < 16; ++$Z){

--- a/src/pocketmine/level/generator/Flat.php
+++ b/src/pocketmine/level/generator/Flat.php
@@ -106,7 +106,7 @@ class Flat extends Generator{
 		}
 
 
-		$this->chunk = $this->level->getChunk(0, 0);
+		$this->chunk = clone $this->level->getChunk(0, 0);
 		$this->chunk->setGenerated();
 
 		for($Z = 0; $Z < 16; ++$Z){


### PR DESCRIPTION
The Flat generator destroys Chunk at 0,0.

What happens is that it request the level to read Chunk at 0,0.  It then uses that chunk to create the template chunk.  However this obliterates whatever was in Chunk at 0,0.

Added a line to "clone" this chunk, so when parsePreset generates the template chunk, all this goes to a copy rather than the original file chunk 0,0.

This would fix issue #2787 