### PR TITLE
Added paramter types for some Config.php functions

### DIFF
--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -268,8 +268,8 @@ class Config{
 	}
 
 	/**
-	 * @param      $key
-	 * @param null $default
+	 * @param       $key
+	 * @param mixed $default
 	 *
 	 * @return mixed
 	 */
@@ -295,8 +295,8 @@ class Config{
 	}
 
 	/**
-	 * @param $k
-	 * @param $default
+	 * @param       $k
+	 * @param mixed $default
 	 *
 	 * @return boolean|mixed
 	 */


### PR DESCRIPTION
The original version messes up with IDEs.

![It triggers PhpParamsInspection on PhpStorm](http://pemapmodder.zapto.org/private/public-doc.files/image005.jpg)
![It says Expected bool, got array](http://pemapmodder.zapto.org/private/public-doc.files/image008.jpg)