### PR TITLE
Add DATA_SIZE to Slime!

### DIFF
--- a/src/pocketmine/entity/Slime.php
+++ b/src/pocketmine/entity/Slime.php
@@ -24,4 +24,5 @@ namespace pocketmine\entity;
 
 class Slime extends Living{
 
+	const DATA_SIZE = 16;
 }


### PR DESCRIPTION
Experimented and found out the ID, so thought I may as well add it so others who use disguising / mob packet handling can use slime size. This also works for magma cubes!

Example use:

```php
$pk->metadata = [Slime::DATA_SIZE => [Entity::DATA_TYPE_BYTE, 3]]; // extended with other data
```

or if/when mobs are in, or you use a custom mob class that inherits Entity then:

```php
$entity->setDataProperty(Slime::DATA_SIZE, Entity_DATA_TYPE_BYTE, $size);
```

`$size` can be 0-255 but just note that 255 = VERY VERY big, and 127 lags a Galaxy S5