### PR TITLE
Is this still needed?

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -712,7 +712,7 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 			}
 
 			$this->noDamageTicks = 60;
-			
+
 			foreach($this->usedChunks as $index => $c){
 				Level::getXZ($index, $chunkX, $chunkZ);
 				foreach($this->level->getChunkEntities($chunkX, $chunkZ) as $entity){
@@ -1489,7 +1489,7 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 
 					return;
 				}
-				
+
 				if(strlen($packet->skin) < 64 * 32 * 4){
 					$this->close("", "disconnectionScreen.invalidSkin", false);
 					return;
@@ -2582,7 +2582,7 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 		}
 		$this->dataPacket($pk->setChannel(Network::CHANNEL_TEXT));
 	}
-	
+
 	public function sendPopup($message){
 		$pk = new TextPacket();
 		$pk->type = TextPacket::TYPE_POPUP;
@@ -2610,7 +2610,7 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 				$pk->message = $reason;
 				$this->directDataPacket($pk->setChannel(Network::CHANNEL_PRIORITY));
 			}
-			
+
 			$this->connected = false;
 			if($this->username != ""){
 				$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message));
@@ -2629,7 +2629,7 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 			foreach($this->windowIndex as $window){
 				$this->removeWindow($window);
 			}
-			
+
 			$this->interface->close($this, $notify ? $reason : "");
 
 			$chunkX = $chunkZ = null;
@@ -2930,6 +2930,21 @@ class Player extends Human implements CommandSender, InventoryHolder, IPlayer{
 
 	public function teleport(Vector3 $pos, $yaw = null, $pitch = null){
 		$oldPos = $this->getPosition();
+
+		// Removes Tile entities that seem to linger whenever you teleport...
+		if (($pos instanceof Position) and ($pos->getLevel() and $pos->getLevel() !== $oldPos->getLevel())) {
+			// We are moving to a different level, delete all tile entity blocks
+			foreach ($oldPos->getLevel()->getTiles() as $tile) {
+				$pk = new UpdateBlockPacket();
+				$pk->x = $tile->x;
+				$pk->y = $tile->y;
+				$pk->z = $tile->z;
+				$pk->block = 0;
+				$pk->meta = 0;
+				$this->dataPacket($pk);
+			}
+		}
+
 		if(parent::teleport($pos, $yaw, $pitch)){
 
 			foreach($this->windowIndex as $window){


### PR DESCRIPTION
With MCPE0.10 very often when you teleport between worlds you will be looking at TileEntities (chests, signs, etc) from the originating world being left around the destination world.  You could see them, but you couldn't interact with them. (Couldn't touch or break them).

I am not part of the beta program, so I can not test this, but does this still happen in MCPE0.11?

If this still happens, I had code in ManyWorlds that would send UpdateBlockPackets before teleporting to clear-up those TileEntities so as to make sure that there are no tile entities that would get left behind after the new chunks are sent.  Would this fix that particular glitch?

Finally, if it does fix that particular glitch, would this patch be worth of consideration for merging into PocketMine-MP?

PS: Apologies, my text editor though it would be fun to remove the lines with only tabs with empty lines, so those changes also got to the commit.

