### PR TITLE
Added  PluginBase::getResourceContents

### DIFF
--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -187,6 +187,23 @@ abstract class PluginBase implements Plugin{
 	}
 
 	/**
+	 * Gets the contents of an embedded resource on the plugin file.
+	 *
+	 * @param string $filename
+	 *
+	 * @return string, or null
+	 */
+	public function getResourceContents($filename){
+		$fp = $this->getResource($filename);
+		if($fp === null){
+			return null;
+		}
+		$contents = stream_get_contents($fp);
+		fclose($fp);
+		return $contents;
+	}
+
+	/**
 	 * @param string $filename
 	 * @param bool   $replace
 	 *

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -191,7 +191,7 @@ abstract class PluginBase implements Plugin{
 	 *
 	 * @param string $filename
 	 *
-	 * @return string, or null
+	 * @return string|null
 	 */
 	public function getResourceContents($filename){
 		$fp = $this->getResource($filename);


### PR DESCRIPTION
Adds a convenient function to PluginBase called getResourceContents.

It is the same idea as file_get_contents, but for resources.
