### PR TITLE
Fix lingering tiles during world teleports

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -590,6 +590,17 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	protected function switchLevel(Level $targetLevel){
 		$oldLevel = $this->level;
 		if(parent::switchLevel($targetLevel)){
+			//TODO HACK: removes tile entities that linger whenever you teleport
+			// to a different world
+			$pk = new UpdateBlockPacket();
+			foreach($oldLevel->getTiles() as $tile){
+				$pk->records[] = [$tile->x, $tile->z, $tile->y, 0, 0, UpdateBlockPacket::FLAG_NONE];
+			}
+			if(count($pk->records)){
+				$this->dataPacket($pk);
+			}
+			//----
+
 			foreach($this->usedChunks as $index => $d){
 				Level::getXZ($index, $X, $Z);
 				$this->unloadChunk($X, $Z, $oldLevel);
@@ -1638,7 +1649,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 					break;
 				}
-				
+
 				if(strlen($packet->skin) !== 64 * 32 * 4 and strlen($packet->skin) !== 64 * 64 * 4){
 					$this->close("", "disconnectionScreen.invalidSkin");
 					break;
@@ -2825,7 +2836,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}
 		$this->dataPacket($pk->setChannel(Network::CHANNEL_TEXT));
 	}
-	
+
 	public function sendPopup($message){
 		$pk = new TextPacket();
 		$pk->type = TextPacket::TYPE_POPUP;
@@ -2856,7 +2867,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$pk->message = $reason;
 				$this->directDataPacket($pk->setChannel(Network::CHANNEL_PRIORITY));
 			}
-			
+
 			$this->connected = false;
 			if(strlen($this->getName()) > 0){
 				$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message, true));

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -598,17 +598,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	protected function switchLevel(Level $targetLevel){
 		$oldLevel = $this->level;
 		if(parent::switchLevel($targetLevel)){
-			//TODO HACK: removes tile entities that linger whenever you teleport
-			// to a different world
-			$pk = new UpdateBlockPacket();
-			foreach($oldLevel->getTiles() as $tile){
-				$pk->records[] = [$tile->x, $tile->z, $tile->y, 0, 0, UpdateBlockPacket::FLAG_NONE];
-			}
-			if(count($pk->records)){
-				$this->dataPacket($pk);
-			}
-			//----
-
 			foreach($this->usedChunks as $index => $d){
 				Level::getXZ($index, $X, $Z);
 				$this->unloadChunk($X, $Z, $oldLevel);
@@ -631,6 +620,16 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					$entity->despawnFrom($this);
 				}
 			}
+			//TODO HACK: removes tile entities that linger whenever you teleport
+			// to a different world
+			$pk = new UpdateBlockPacket();
+			foreach($level->getChunkTiles($x, $z) as $tile){
+				$pk->records[] = [$tile->x, $tile->z, $tile->y, 0, 0, UpdateBlockPacket::FLAG_NONE];
+			}
+			if(count($pk->records)){
+				$this->dataPacket($pk);
+			}
+			//----
 
 			unset($this->usedChunks[$index]);
 		}


### PR DESCRIPTION
New Pull Request in switchLevel

When somebody teleports between worlds Tile objects that used to be in the departure world keep lingering in the destination world.  These can be seen but cannot be interact with.
This pull request introduces a work around to solve these.

This is how the issue looks like:

<img src="http://forums.pocketmine.net/attachments/photo-1-png.6770/"/>

<img src="http://forums.pocketmine.net/attachments/photo-2-png.6771/"/>
