### PR TITLE
Fixes #3173

### DIFF
--- a/src/pocketmine/level/generator/normal/biome/OceanBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/OceanBiome.php
@@ -28,10 +28,13 @@ class OceanBiome extends GrassyBiome{
 	public function __construct(){
 		parent::__construct();
 
-		$tallGrass = new TallGrass();
-		$tallGrass->setBaseAmount(5);
-
-		$this->addPopulator($tallGrass);
+		$this->setGroundCover([
+			Block::get(Block::DIRT, 0),
+			Block::get(Block::DIRT, 0),
+			Block::get(Block::DIRT, 0),
+			Block::get(Block::DIRT, 0),
+			Block::get(Block::DIRT, 0),
+		]);
 
 		$this->setElevation(46, 58);
 


### PR DESCRIPTION
Gets rid of useless Tall Grass Populator and fixes issue #3173 by setting the ground cover to just be dirt and not grass on top.