### PR TITLE
Prevent issues with colored display names

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -237,7 +237,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 	public function getLeaveMessage(){
 		return new TranslationContainer(TextFormat::YELLOW . "%multiplayer.player.left", [
-			$this->getDisplayName()
+			$this->getDisplayName() . TextFormat::YELLOW
 		]);
 	}
 
@@ -732,7 +732,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$this->server->getPluginManager()->callEvent($ev = new PlayerJoinEvent($this,
 			new TranslationContainer(TextFormat::YELLOW . "%multiplayer.player.joined", [
-				$this->getDisplayName()
+				$this->getDisplayName() . TextFormat::YELLOW
 			])
 		));
 		if(strlen(trim($ev->getJoinMessage())) > 0){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2474,7 +2474,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 							}else{
 								$this->server->getPluginManager()->callEvent($ev = new PlayerChatEvent($this, $ev->getMessage()));
 								if(!$ev->isCancelled()){
-									$this->server->broadcastMessage($this->getServer()->getLanguage()->translateString($ev->getFormat(), [$ev->getPlayer()->getDisplayName(), $ev->getMessage()]), $ev->getRecipients());
+									$this->server->broadcastMessage($this->getServer()->getLanguage()->translateString($ev->getFormat(), [$ev->getPlayer()->getDisplayName() . TextFormat::RESET, $ev->getMessage()]), $ev->getRecipients());
 								}
 							}
 						}


### PR DESCRIPTION
When plugins add custom "display names" with color codes, PocketMine and Chat messages are colored as the "display name" is... This is intended to correct that :3

For the Chat messages, the "suffix" of player's display name is colored too, for example, with the format ``<%s>%s``, the part ``%s>%s`` will be with the same color (Unless a chat plugin modify the format or the player use other color codes in chat)