### PR TITLE
Fixes first respawn when spawning in non-default level.

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -746,6 +746,8 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$pk->z = $pos->z;
 		$this->dataPacket($pk->setChannel(Network::CHANNEL_WORLD_CHUNKS));
 
+		$this->level = $pos->level;
+
 		$pk = new PlayStatusPacket();
 		$pk->status = PlayStatusPacket::PLAYER_SPAWN;
 		$this->dataPacket($pk->setChannel(Network::CHANNEL_WORLD_CHUNKS));


### PR DESCRIPTION
Does as it says in the title. Fixes when the very first PlayerRespawnEvent sets a position in a different level.