### PR TITLE
AddPlayerPacket.item must be instanceof Item

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -237,8 +237,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 			$pk->speedZ = $this->motionZ;
 			$pk->yaw = $this->yaw;
 			$pk->pitch = $this->pitch;
-			$item = $this->getInventory()->getItemInHand();
-			$pk->item = $item->getId();
+			$pk->item = $this->getInventory()->getItemInHand();
 			$pk->meta = $item->getDamage();
 			$pk->skin = $this->skin;
 			$pk->slim = $this->isSlim;


### PR DESCRIPTION
Fixes this crash:

```
PocketMine-MP Crash Dump Tue Aug 4 22:29:22 UTC 2015
 
Error: Argument 1 passed to pocketmine\utils\BinaryStream::putSlot() must be an instance of pocketmine\item\Item, integer given, called in phar:///home/test/PocketMine-MP.phar/src/pocketmine/network/protocol/AddPlayerPacket.php on line 66 and defined
File: /src/pocketmine/utils/BinaryStream
Line: 218
Type: notice
 
Code:
[209]
[210]           return Item::get(
[211]                   $id,
[212]                   $data,
[213]                   $cnt,
[214]                   $nbt
[215]           );
[216]   }
[217]
[218]   public function putSlot(Item $item){
[219]           if($item->getId() === 0){
[220]                   $this->putShort(0);
[221]                   return;
[222]           }
[223]          
[224]           $this->putShort($item->getId());
[225]           $this->putByte($item->getCount());
[226]           $this->putShort($item->getDamage() === null ? -1 : $item->getDamage());
[227]           $nbt = $item->getCompoundTag();
[228]           $this->putShort(strlen($nbt));
 
Backtrace:
#0 /src/pocketmine/network/protocol/AddPlayerPacket(66): pocketmine\utils\BinaryStream->putSlot(integer 0)
#1 /src/pocketmine/network/RakLibInterface(203): pocketmine\network\protocol\AddPlayerPacket->encode(boolean)
#2 /src/pocketmine/Player(912): pocketmine\network\RakLibInterface->putPacket(pocketmine\Player Player(2), pocketmine\network\protocol\AddPlayerPacket object, boolean , boolean )
#3 /src/pocketmine/entity/Human(246): pocketmine\Player->dataPacket(pocketmine\network\protocol\AddPlayerPacket object)
#4 /src/pocketmine/Player(326): pocketmine\entity\Human->spawnTo(pocketmine\Player Player(2))
#5 /src/pocketmine/Player(764): pocketmine\Player->spawnTo(pocketmine\Player Player(2))
#6 /src/pocketmine/Player(713): pocketmine\Player->doFirstSpawn(boolean)
#7 /src/pocketmine/Player(1554): pocketmine\Player->sendNextChunk(boolean)
#8 /src/pocketmine/Server(2571): pocketmine\Player->checkNetwork(boolean)
#9 /src/pocketmine/Server(2308): pocketmine\Server->tick(boolean)
#10 /src/pocketmine/Server(2186): pocketmine\Server->tickProcessor(boolean)
#11 /src/pocketmine/Server(1786): pocketmine\Server->start(boolean)
#12 /src/pocketmine/PocketMine(464): pocketmine\Server->__construct(pocketmine\CompatibleClassLoader object, pocketmine\utils\MainLogger object, string phar:///home/test/PocketMine-MP.phar/, string /home/test/, string /home/test/plugins/)
#13 (1): require_once(string phar:///home/test/PocketMine-MP.phar/src/pocketmine/PocketMine.php)
 
PocketMine-MP version: 1.6dev #0 [Protocol 31; API 1.13.0]
Git commit: 0000000000000000000000000000000000000000
uname -a: Linux cake 3.10.0-123.9.3.el7.onapp.1.x86_64 #1 SMP Thu Dec 4 15:02:06 EET 2014 x86_64
PHP Version: 5.6.2
Zend version: 2.6.0
OS : Linux, linux
```