### PR TITLE
Prevent plugins crashing the server by requesting permissions for users that have gone offline

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -436,6 +436,14 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 * @return bool
 	 */
 	public function hasPermission($name){
+		if(is_null($this)) {
+			$this->server->getLogger()->warning("Failed to read permission " . $name ." because Player has gone - assuming false");
+			return false;
+		}
+		if(is_null($this->perm)) {
+                        $this->server->getLogger()->warning("Failed to read permission " . $name ." because Player has gone - assuming false");
+                        return false;
+                }
 		return $this->perm->hasPermission($name);
 	}
 


### PR DESCRIPTION
This is of course an issue that should be fixed plugin side but without this defensive coding it is hard to even identify what plugin is causing the issue - the error I was getting constantly before in the crash logs on our server was

PocketMine-MP Crash Dump Sat Aug 15 09:56:24 BST 2015                                                                                [0/624]

Error: Call to a member function hasPermission() on null
File: /src/pocketmine/Player__64bit
Line: 439
Type: E_ERROR

Code:
[430]           return $this->perm->isPermissionSet($name);
[431]   }
[432]
[433]   /**
[434]    * @param permission\Permission|string $name
[435]    *
[436]    * @return bool
[437]    */
[438]   public function hasPermission($name){
[439]           return $this->perm->hasPermission($name);
[440]   }
[441] 
[442]   /**
[443]    * @param Plugin $plugin
[444]    * @param string $name
[445]    * @param bool   $value
[446]    *
[447]    * @return permission\PermissionAttachment
[448]    */
[449]   public function addAttachment(Plugin $plugin, $name = \null, $value = \null){

Backtrace: 
#0 (): pocketmine\Server->crashDump()

Now after running with this change I can see many prevented crashes

cat server.log | grep "assuming false"
2015-08-17 [02:01:22] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [02:01:22] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [02:01:22] [Server thread/WARNING]: Failed to read permission essentials.afk.kickexempt because Player has gone - assuming false
2015-08-17 [02:19:22] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [02:19:22] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [02:19:22] [Server thread/WARNING]: Failed to read permission essentials.afk.kickexempt because Player has gone - assuming false
2015-08-17 [03:43:52] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [03:43:52] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [04:32:22] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [04:32:22] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [05:05:52] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [05:05:52] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [08:31:23] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [08:31:23] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [10:26:24] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [10:26:24] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [10:36:54] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [10:36:54] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [10:36:54] [Server thread/WARNING]: Failed to read permission essentials.afk.kickexempt because Player has gone - assuming false
2015-08-17 [11:13:25] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [11:13:25] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [17:16:41] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [17:16:41] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [17:51:19] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [17:51:19] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [18:29:50] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [18:29:50] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [19:06:20] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [19:06:20] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [19:06:20] [Server thread/WARNING]: Failed to read permission essentials.afk.kickexempt because Player has gone - assuming false
2015-08-17 [21:39:57] [Server thread/WARNING]: Failed to read permission essentals.afk.preventauto because Player has gone - assuming false
2015-08-17 [21:39:57] [Server thread/WARNING]: Failed to read permission essentials.mute.notify because Player has gone - assuming false
2015-08-17 [21:39:57] [Server thread/WARNING]: Failed to read permission essentials.afk.kickexempt because Player has gone - assuming false

So I can at least see that Essentials is causing the issue now and the issue is no longer fatal.
