### PR TITLE
Handle script plugin lists

### DIFF
--- a/src/pocketmine/plugin/ScriptPluginLoader.php
+++ b/src/pocketmine/plugin/ScriptPluginLoader.php
@@ -106,6 +106,15 @@ class ScriptPluginLoader implements PluginLoader{
 			}
 		}
 		if($insideHeader){
+			/*
+			 * We go through the description and make sure that array
+			 * tags are indeed arrays...
+			 */
+			foreach(["depend", "softdepend", "loadbefore", "api", "authors"] as $key){
+				if(isset($data[$key])) {
+					$data[$key] = preg_split("/\s*,\s*/", $data[$key]);
+				}
+			}
 			return new PluginDescription($data);
 		}
 


### PR DESCRIPTION
The plugin.yml has some items that are supposed to be arrays.  This changes the ScriptPluginLoader to make sure that those items are indeed arrays.
