### PR TITLE
Block cache not cleared with a call to clearcache

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -855,7 +855,7 @@ class Level implements ChunkManager, Metadatable{
 			}
 
 			if(count($this->blockCache) > 2048){
-				$this->chunkCache = [];
+				$this->blockCache = [];
 			}
 
 		}


### PR DESCRIPTION
While trying to figure out Github and looking for a different bug I found this small bug in the code. The ClearCache function on Level.php did not correctly clear the blockcache.