### PR TITLE
First item in the hotbar is not loaded correctly

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1769,7 +1769,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				if($this->isCreative()){
 					$this->inventory->setHeldItemSlot(0);
 				}else{
-					$this->inventory->setHeldItemSlot(0);
+					$this->inventory->setHeldItemSlot($this->inventory->getHotbarSlotIndex(0));
 				}
 
 				$pk = new PlayStatusPacket();


### PR DESCRIPTION
When you logon the first hotbar item contains the first item of the inventory, but it should contain the previously selected item.