### PR TITLE
Fixed DoorSound won't be played

### DIFF
--- a/src/pocketmine/block/FenceGate.php
+++ b/src/pocketmine/block/FenceGate.php
@@ -23,6 +23,7 @@ namespace pocketmine\block;
 
 use pocketmine\item\Item;
 use pocketmine\item\Tool;
+use pocketmine\level\sound\DoorSound;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\Player;
 

--- a/src/pocketmine/block/Trapdoor.php
+++ b/src/pocketmine/block/Trapdoor.php
@@ -24,6 +24,7 @@ namespace pocketmine\block;
 use pocketmine\item\Item;
 use pocketmine\item\Tool;
 use pocketmine\math\AxisAlignedBB;
+use pocketmine\level\sound\DoorSound;
 use pocketmine\Player;
 
 class Trapdoor extends Transparent{


### PR DESCRIPTION
missing "use pocketmine\level\sound\DoorSound;" in Trapdoor.php and FenceGate.php .
This will fix #3444 .
