### PR TITLE
Added Player to CraftItemEvent

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1863,7 +1863,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 					break;
 				}
-				
+
 				if(strlen($packet->skin) !== 64 * 32 * 4 and strlen($packet->skin) !== 64 * 64 * 4){
 					$this->close("", "disconnectionScreen.invalidSkin");
 					break;
@@ -2719,7 +2719,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					break;
 				}
 
-				$this->server->getPluginManager()->callEvent($ev = new CraftItemEvent($ingredients, $recipe));
+				$this->server->getPluginManager()->callEvent($ev = new CraftItemEvent($this, $ingredients, $recipe));
 
 				if($ev->isCancelled()){
 					$this->inventory->sendContents($this);
@@ -2985,7 +2985,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}
 		$this->dataPacket($pk);
 	}
-	
+
 	public function sendPopup($message, $subtitle = ""){
 		$pk = new TextPacket();
 		$pk->type = TextPacket::TYPE_POPUP;
@@ -3017,7 +3017,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$pk->message = $reason;
 				$this->directDataPacket($pk);
 			}
-			
+
 			$this->connected = false;
 			if(strlen($this->getName()) > 0){
 				$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message, true));

--- a/src/pocketmine/event/inventory/CraftItemEvent.php
+++ b/src/pocketmine/event/inventory/CraftItemEvent.php
@@ -25,6 +25,7 @@ use pocketmine\event\Cancellable;
 use pocketmine\event\Event;
 use pocketmine\inventory\Recipe;
 use pocketmine\item\Item;
+use pocketmine\Player;
 
 class CraftItemEvent extends Event implements Cancellable{
 	public static $handlerList = null;
@@ -33,12 +34,17 @@ class CraftItemEvent extends Event implements Cancellable{
 	private $input = [];
 	/** @var Recipe */
 	private $recipe;
+	/** @var \pocketmine\Player */
+	private $player;
+
 
 	/**
+	 * @param \pocketmine\Player $player
 	 * @param Item[] $input
 	 * @param Recipe $recipe
 	 */
-	public function __construct(array $input, Recipe $recipe){
+	public function __construct(Player $player, array $input, Recipe $recipe){
+		$this->player = $player;
 		$this->input = $input;
 		$this->recipe = $recipe;
 	}
@@ -62,4 +68,10 @@ class CraftItemEvent extends Event implements Cancellable{
 		return $this->recipe;
 	}
 
+	/**
+	 * @return \pocktemine\Player
+	 */
+	public function getPlayer(){
+		return $this->player;
+	}
 }


### PR DESCRIPTION
This add a getPlayer method to the CraftItemEvent.  This is needed to enable SimpleAuth to cancel the crafting event if the player is not yet authenticated.
