### PR TITLE
Added missing logException method

### DIFF
--- a/src/pocketmine/plugin/PluginLogger.php
+++ b/src/pocketmine/plugin/PluginLogger.php
@@ -93,4 +93,8 @@ class PluginLogger implements \AttachableLogger{
 			$attachment->log($level, $message);
 		}
 	}
+
+	public function logException(\Throwable $e, $trace = null){
+		Server::getInstance()->getLogger()->logException($e,$trace);
+	}
 }


### PR DESCRIPTION
Adding missing logException method to PluginLogger (php7 branch, 2.0.0 API)
