### PR TITLE
Make sure Level::tickRateTime is (int)

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2251,7 +2251,7 @@ class Server{
 				$levelTime = microtime(true);
 				$level->doTick($currentTick);
 				$tickMs = (microtime(true) - $levelTime) * 1000;
-				$level->tickRateTime = $tickMs;
+				$level->tickRateTime = (int)$tickMs;
 
 				if($this->autoTickRate){
 					if($tickMs < 50 and $level->getTickRate() > $this->baseTickRate){


### PR DESCRIPTION
tickRateTime should be an int (according to the getTickRateTime signature).
