### PR TITLE
Allow escape for period in config nested keys

### DIFF
--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -259,7 +259,18 @@ class Config{
 	 * @param $value
 	 */
 	public function setNested($key, $value){
-		$vars = explode(".", $key);
+		$vars = [];
+		$current = "";
+		foreach(explode(".", $key) as $var){
+			if(substr($var, -1) === "\\"){
+				$current .= $var . ".";
+			}else{
+				$var = $current . $var;
+				$current = "";
+				$vars[] = $var;
+			}
+		}
+		
 		$base = array_shift($vars);
 
 		if(!isset($this->config[$base])){
@@ -291,7 +302,18 @@ class Config{
 			return $this->nestedCache[$key];
 		}
 
-		$vars = explode(".", $key);
+		$vars = [];
+		$current = "";
+		foreach(explode(".", $key) as $var){
+			if(substr($var, -1) === "\\"){
+				$current .= $var . ".";
+			}else{
+				$var = $current . $var;
+				$current = "";
+				$vars[] = $var;
+			}
+		}
+		
 		$base = array_shift($vars);
 		if(isset($this->config[$base])){
 			$base = $this->config[$base];


### PR DESCRIPTION
Expected result:

```json
{
  "a": {
    "b.c": "b period c",
    "b": {
      "c": "b slash c"
    }
  }
}
```

```php
$config = new Config("abc.json", Config::JSON);
var_dump($config->getNested('a.b\.c')); // string(10) "b period c"
var_dump($config->getNested("a.b.c")); // string(9) "b slash c"
```

Note: this mechanism isn't fully tested.