### PR TITLE
Fix return type

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2705,7 +2705,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int
 	 */
 	public function getSeed() : int{
-		return $this->provider->getSeed();
+		return (int)$this->provider->getSeed();
 	}
 
 	/**


### PR DESCRIPTION
Fix error:
[Server thread/CRITICAL]: TypeError: "Return value of pocketmine\level\Level::getSeed() must be of the type integer, string returned in /root/src/pocketmine/level/Level.php on line 2708" (EXCEPTION) in "/src/pocketmine/level/Level" at line 2708