### PR TITLE
Added additional information to Plugin::getDataFolder()

### DIFF
--- a/src/pocketmine/plugin/Plugin.php
+++ b/src/pocketmine/plugin/Plugin.php
@@ -54,7 +54,8 @@ interface Plugin extends CommandExecutor{
 	public function isDisabled();
 
 	/**
-	 * Gets the plugin's data folder to save files and configuration
+	 * Gets the plugin's data folder to save files and configuration.
+	 * This directory name has a trailing slash.
 	 */
 	public function getDataFolder();
 


### PR DESCRIPTION
Without this, a new developer is likely to have to test or browse through plugin loaders to find out whether this is true.