### PR TITLE
Fixed hasPermission() crash - attempt 2

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -436,7 +436,10 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 * @return bool
 	 */
 	public function hasPermission($name){
-		return $this->perm->hasPermission($name);
+		 if(is_null($this->perm)) {
++         return false;
++     }
++     return $this->perm->hasPermission($name);
 	}
 
 	/**

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -437,9 +437,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 */
 	public function hasPermission($name){
 		 if(is_null($this->perm)) {
-+         return false;
-+     }
-+     return $this->perm->hasPermission($name);
+        return false;
+     }
+     return $this->perm->hasPermission($name);
 	}
 
 	/**


### PR DESCRIPTION
When you use hasPermission() when the player is offline (eg. you do it in PlayerPreLoginEvent) it crashes, but this fixes the crash but the error yeah.

so this works fine, @64FF00 's suggestion wasn't working as @Sekjun9878 said, but i commited her way... 
so i hope you can merge this.