### PR TITLE
Resolved #3694

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1681,7 +1681,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$this->server->getPluginManager()->callEvent($ev = new PlayerPreLoginEvent($this, "Plugin reason"));
 				if($ev->isCancelled()){
 					$this->close("", $ev->getKickMessage());
-
+					break;
+				}
+				if($this->closed){
 					break;
 				}
 
@@ -1762,7 +1764,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$this->server->getPluginManager()->callEvent($ev = new PlayerLoginEvent($this, "Plugin reason"));
 				if($ev->isCancelled()){
 					$this->close($this->getLeaveMessage(), $ev->getKickMessage());
-
+					break;
+				}
+				if($this->closed){
 					break;
 				}
 


### PR DESCRIPTION
> Note: same content as the comment in #3694

After `PlayerPreLoginEvent` is called [here](https://github.com/PocketMine/PocketMine-MP/blob/master/src/pocketmine/Player.php#L1681):

### If the event is cancelled
* PocketMine will internally [kick](https://github.com/PocketMine/PocketMine-MP/blob/master/src/pocketmine/Player.php#L1683) the player.
* PocketMine will [stop](https://github.com/PocketMine/PocketMine-MP/blob/master/src/pocketmine/Player.php#L1685) handling the packet.

### If the event is not cancelled
* PocketMine will **not** [stop](https://github.com/PocketMine/PocketMine-MP/blob/master/src/pocketmine/Player.php#L1685) handling the packet
* PocketMine continues handling the login checks, until [PocketMine attempts to subscribe the player to chat permissions](https://github.com/PocketMine/PocketMine-MP/blob/master/src/pocketmine/Player.php#L1698), which involves a `hasPermission` call.

Unlike what some would have guessed, it is not true that the permissible base is not initialized when the player is not logged in. Actually, `Player->perm` is [one of the earliest fields initialized in the constructor](https://github.com/PocketMine/PocketMine-MP/blob/master/src/pocketmine/Player.php#L495), but is [nulled when the player leaves](https://github.com/PocketMine/PocketMine-MP/blob/master/src/pocketmine/Player.php#L2946), probably trying to prevent memory leak.

This pull request apparently prevents **this** error of hasPermission() on null from happening, but it is wrong anyway for PocketMine to attempt to run too much code (lines 1688-1847) pointlessly.

Actually, the state of events being dispatched is an awkward moment for well-documented APIs. For instance, when PlayerPreLoginEvent is being handled, does the player logging in get included in `Server->getOnlinePlayers()`? It sounds like the player is _pre_ login, i.e. not logged in, so the player should not be considered as "online", but as a matter of fact, `Server->addPlayer` was triggered by `RakLibInterface::openSession` right after the construction of a Player object, and it is really awkward - as PlayerPreLoginEvent and getOnlinePlayers are loosely related, it is not reasonable to include such specific information about each other in their documentation.

Here we have a similar case. It is perfectly reasonable to call `kick` on a player object anywhere, and it isn't too reasonable for PocketMine (but possible) to check if player has been closed after calling the events. It is neither the developer's nor PocketMine's obvious mistake, but it is preventable by explicitly checking it after calling an event.