### PR TITLE
Change Item constructor visibility to protected

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -1129,7 +1129,7 @@ class Item{
 		}
 	}
 
-	public function __construct($id, $meta = 0, $count = 1, $name = "Unknown"){
+	protected function __construct($id, $meta = 0, $count = 1, $name = "Unknown"){
 		$this->id = $id & 0xffff;
 		$this->meta = $meta !== null ? $meta & 0xffff : null;
 		$this->count = (int) $count;


### PR DESCRIPTION
External callers should use `Item::get()` instead of `new Item`