### PR TITLE
Fix Stair.php : add "use pocketmine\item\Tool;"

### DIFF
--- a/src/pocketmine/block/Stair.php
+++ b/src/pocketmine/block/Stair.php
@@ -22,6 +22,7 @@
 namespace pocketmine\block;
 
 use pocketmine\item\Item;
+use pocketmine\item\Tool;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\Player;
 


### PR DESCRIPTION
Without this >= Tool::TIER_WOODEN does not work; so stone stairs do not give drops when broken. They also revert to not being broken on next connection.