### PR TITLE
getDrops() missing line (?), incorrect return statement

### DIFF
--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -754,6 +754,8 @@ class Block extends Position implements Metadatable{
 		}else{
 			return [
 				[$this->getId(), $this->getDamage(), 1],
+				//By adding this line below, the method will return a proper array and actually make use of $item.
+				[$item->getId(), $item->getDamage(), $item->getCount()]
 			];
 		}
 	}


### PR DESCRIPTION
Methods calling Block::getDrops() expect an array of tuples (not exactly Item objects) which in turn will be passed to Item::get() or similar methods to get the actual Item objects. Such a method is Explosion::explodeB().

But since Block::getDrops is returning an ackward array with just one tuple, the calling method will trigger an exception which logs critical messages to the server. Some users have reported this criticial message present for quite some time during gameplay.

In addition, the $item argument here is never used inside the method, which makes me believe there's something missing in the return statement, probably a line that got lost during some previous commit.

By adding this line (758), the method will return a proper array and actually make use of $item. It all seems to make sense for a method that is nothing more than a formatter.