### PR TITLE
Fix the server crash when player spawn back to Y coord. >0 & <1

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2657,7 +2657,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return bool|Position
 	 */
 	public function getSafeSpawn($spawn = null){
-		if(!($spawn instanceof Vector3) or $spawn->y <= 0){
+		if(!($spawn instanceof Vector3) or $spawn->y < 1){
 			$spawn = $this->getSpawnLocation();
 		}
 		if($spawn instanceof Vector3){


### PR DESCRIPTION
If a player is creative he can mine the lowest bedrock level . Then after If the player go into the void leave and go back in the game then the server crash due to a getBlockId with Y coordinate below 0 (-1).
