### PR TITLE
PR: Bug Fix - Crash if player is spawn to Y coord. >0 & <1

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2657,7 +2657,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return bool|Position
 	 */
 	public function getSafeSpawn($spawn = null){
-		if(!($spawn instanceof Vector3) or $spawn->y <= 0){
+		if(!($spawn instanceof Vector3) or $spawn->y < 1){
 			$spawn = $this->getSpawnLocation();
 		}
 		if($spawn instanceof Vector3){


### PR DESCRIPTION
**Original issue:**
When player is in creative mode and mine the lowest bedrock and fly at the bedrock level (Y coordinate above 0 and lower than 1) 
then after if the player quit the server and come back, the server crash on getBlockId function with a Y coordinate at -1.

**Fix:**
 in level/level.php , getSafeSpawn is modified in order to consider that  player spawn Y location below 1  is  0 ,then use current level SpawnLocation.
