### PR TITLE
Show Travis-CI Build Status on README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ![PocketMine-MP](http://cdn.pocketmine.net/img/PocketMine-MP-h.png)
+[![Build Status](https://travis-ci.org/PocketMine/PocketMine-MP.svg?branch=master)](https://travis-ci.org/PocketMine/PocketMine-MP)
 
 
 	This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
For Github visitors, many projects shows its project build status in README.md.
It would be nice if PocketMine-MP shows Travis-CI build status, too.
Here is the sample layout in this PR branch.

https://github.com/dongjoon-hyun/PocketMine-MP/tree/show_travis_build_status

Signed-off-by: Dongjoon Hyun <dongjoon@apache.org>