### PR TITLE
PR-bugfix : getSeed expect an int and not a string

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2705,7 +2705,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int
 	 */
 	public function getSeed() : int{
-		return $this->provider->getSeed();
+		return intval( $this->provider->getSeed() );
 	}
 
 	/**


### PR DESCRIPTION
**Issue:**
crash dump with
Error: Return value of pocketmine\level\Level::getSeed() must be of the type integer, string returned
File: /src/pocketmine/level/Level
Line: 2708

**Fix:**
be sure to provide a "int" by converting the seed value by using intval