### PR TITLE
Revert "[php7-0.14] Update BaseLevelProvider.php"

### DIFF
--- a/src/pocketmine/level/format/generic/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/generic/BaseLevelProvider.php
@@ -87,7 +87,7 @@ abstract class BaseLevelProvider implements LevelProvider{
 		$this->levelData->Time = new IntTag("Time", (int) $value);
 	}
 
-	public function getSeed() : int{
+	public function getSeed(){
 		return $this->levelData["RandomSeed"];
 	}
 


### PR DESCRIPTION
Reverts PocketMine/PocketMine-MP#3934

I need to revert this, because it involves compatibility with parent and child classes.