### PR TITLE
Added settings.incompatible-plugins in pocketmine.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ timings/*
 *.log
 *.txt
 *.phar
-server.properties
-pocketmine.yml
+/server.properties
+/pocketmine.yml
 
 # Common IDEs
 .idea/*

--- a/src/pocketmine/lang/BaseLang.php
+++ b/src/pocketmine/lang/BaseLang.php
@@ -79,14 +79,15 @@ class BaseLang{
 	}
 
 	/**
-	 * @param string   $str
-	 * @param string[] $params
+	 * @param string      $str
+	 * @param string[]    $params
+	 * @param string|null $onlyPrefix
 	 *
 	 * @return string
 	 */
 	public function translateString($str, array $params = [], $onlyPrefix = null){
 		$baseText = $this->get($str);
-		$baseText = $this->parseTranslation( ($baseText !== null and ($onlyPrefix === null or strpos($str, $onlyPrefix) === 0)) ? $baseText : $str, $onlyPrefix);
+		$baseText = $this->parseTranslation(($baseText !== null and ($onlyPrefix === null or strpos($str, $onlyPrefix) === 0)) ? $baseText : $str, $onlyPrefix);
 
 		foreach($params as $i => $p){
 			$baseText = str_replace("{%$i}", $this->parseTranslation((string) $p), $baseText, $onlyPrefix);
@@ -98,7 +99,7 @@ class BaseLang{
 	public function translate(TextContainer $c){
 		if($c instanceof TranslationContainer){
 			$baseText = $this->internalGet($c->getText());
-			$baseText = $this->parseTranslation( $baseText !== null ? $baseText : $c->getText());
+			$baseText = $this->parseTranslation($baseText !== null ? $baseText : $c->getText());
 
 			foreach($c->getParameters() as $i => $p){
 				$baseText = str_replace("{%$i}", $this->parseTranslation($p), $baseText);

--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -14,6 +14,8 @@ settings:
  query-plugins: true
  #Show a console message when a plugin uses deprecated API methods
  deprecated-verbose: true
+ #Load plugins even if they have incompatible API versions
+ incompatible-plugins: false
  #Enable plugin and core profiling by default
  enable-profiling: false
  #Will only add results when tick measurement is below or equal to given value (default 20)


### PR DESCRIPTION
After showing a warning in output, load the plugins with incompatible API versions if `settings.incompatible-plugins` is enabled in `pocketmine.yml`