### PR TITLE
Allows @notscript tag in script plugins

### DIFF
--- a/src/pocketmine/plugin/ScriptPluginLoader.php
+++ b/src/pocketmine/plugin/ScriptPluginLoader.php
@@ -98,6 +98,10 @@ class ScriptPluginLoader implements PluginLoader{
 				$key = $matches[1];
 				$content = trim($matches[2]);
 
+				if($key === "notscript"){
+					return null;
+				}
+
 				$data[$key] = $content;
 			}
 


### PR DESCRIPTION
This allows files in the plugins folder to contain `.php` files that contain `/**` but are not script plugins.