### PR TITLE
Added options to load plugins of incompatible APIs

### DIFF
--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -23,6 +23,16 @@ settings:
  #Set this approximately to your number of cores.
  #If set to auto, it'll try to detect the number of cores (or use 2)
  async-workers: auto
+ #Load plugins with incompatible API versions
+ #Enabling these options may result in the server loading plugins that are incompatible, hence crashing the server or causing other issues
+ incompatible-plugins:
+  plugin-too-new:
+   #Load plugins whose major API version is too new
+   major: false
+   #Load plugins whose minor API version is too new
+   minor: false
+  #Load plugins whose major API version is too old
+  plugin-too-old: false
 
 memory:
  #Global soft memory limit in megabytes. Set to 0 to disable


### PR DESCRIPTION
Separated into three cases - `>.?.?`, `<.?.?`, `=.>.?`. Can be adjusted using `pocketmine.yml`.

@Intyre is assigned for [adding the language lines](https://twitter.com/shoghicp/status/712687759287160832)

Will not be tested or merged until there is the relevant language file support.
