### PR TITLE
Fix undefined method RCONInstance::kill()

### DIFF
--- a/src/pocketmine/network/rcon/RCON.php
+++ b/src/pocketmine/network/rcon/RCON.php
@@ -70,9 +70,8 @@ class RCON{
 	public function stop(){
 		for($n = 0; $n < $this->threads; ++$n){
 			$this->workers[$n]->close();
-			Server::microSleep(50000);
-			$this->workers[$n]->kill();
 		}
+		Server::microSleep(50000);
 		@socket_close($this->socket);
 		$this->threads = 0;
 	}


### PR DESCRIPTION
Since pthreads no longer support Thread::kill() and Thread::detach(), remove $this->workers[$n]->kill() in RCON.php to prevent exceptions in order to save levels properly. Also, Server::microSleep(50000) will be called after the loop.
