### PR TITLE
fix crash at server stop when RCON is enable

### DIFF
--- a/src/pocketmine/network/rcon/RCON.php
+++ b/src/pocketmine/network/rcon/RCON.php
@@ -71,7 +71,7 @@ class RCON{
 		for($n = 0; $n < $this->threads; ++$n){
 			$this->workers[$n]->close();
 			Server::microSleep(50000);
-			$this->workers[$n]->kill();
+			$this->workers[$n]->quit();
 		}
 		@socket_close($this->socket);
 		$this->threads = 0;


### PR DESCRIPTION
[17:10:36] [Server thread/INFO]: [CONSOLE: Stopping the server]
[17:10:36] [Server thread/EMERGENCY]: Crashed while crashing, killing process
[17:10:36] [Server thread/EMERGENCY]: Error: Call to undefined method pocketmine\network\rcon\RCONInstance::kill()
