### PR TITLE
Fix a horrible entity-related memory leak

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2409,7 +2409,7 @@ class Level implements ChunkManager, Metadatable{
 			unset($this->players[$entity->getId()]);
 			$this->checkSleep();
 		}else{
-			$entity->kill();
+			$entity->close();
 		}
 
 		unset($this->entities[$entity->getId()]);


### PR DESCRIPTION
This commit, simple though it looks, fixes ~~the~~ **a** horrible memory leak that PocketMine and all its forks of have been suffering from since forever.

EDIT: Further explanation is probably warranted.

The problem here, as briefly as I can summarize it, is that entities are leaked on chunk unload.

**Before patch:**
- Chunk is unloaded and saved. All entities on the chunk are saved. Level::removeEntity is called on all entities in that chunk to remove them.
- Level::removeEntity kills non-player entities. Result is items being spawned in an unloaded chunk.
- Movement updates to these entitities (falling checks etc.) trigger requests to the blocks around the entities. Because the entities are in unloaded chunks, these requests cause the chunks to be reloaded. When the chunk is reloaded, the saved entities are spawned again.
- Process repeats, leaking more and more entities until memory limit is exhausted.

**After patch:**
- Chunk is unloaded and saved. All entities on the chunk are saved. Level::removeEntity is called on all entities in that chunk to remove them.
- Because Level::removeEntity now uses close() instead of kill(), no items are dropped, which prevents the leak from beginning.