### PR TITLE
Patched %0 client translation exploit

### DIFF
--- a/src/pocketmine/lang/BaseLang.php
+++ b/src/pocketmine/lang/BaseLang.php
@@ -92,7 +92,7 @@ class BaseLang{
 			$baseText = str_replace("{%$i}", $this->parseTranslation((string) $p), $baseText, $onlyPrefix);
 		}
 
-		return $baseText;
+		return str_replace("%0", "", $baseText);
 	}
 
 	public function translate(TextContainer $c){


### PR DESCRIPTION
There's a client bug/exploit where sending a TextPacket to client with type TYPE_TRANSLATION and containing %0 will cause all connected clients to freeze/crash. This can be observed by saying `/me %0` or `/say %0`. This prevents that from happening by removing the problematic %0.

References:
https://github.com/iTXTech/Genisys/issues/1583